### PR TITLE
feat: Add yaml-cpp as a dependency for EnergyAwareMCPP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set(DEPENDENCIES
   pluginlib
   rosidl_default_generators
   nlohmann_json
+  yaml-cpp
 )
 
 set(LIBRARIES
@@ -60,9 +61,6 @@ set(LIBRARIES
 foreach(DEP IN LISTS DEPENDENCIES)
   find_package(${DEP} REQUIRED)
 endforeach()
-
-# ENERGY_AWARE_MCPP dependencies
-find_package(yaml-cpp REQUIRED)
 
 ## --------------------------------------------------------------
 ## |                      Generate Interfaces                   |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,12 +95,12 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 ## --------------------------------------------------------------
 
 add_library(IrocFleetManager_IrocFleetManager INTERFACE)
-add_library(iroc_fleet_manager::iroc_fleet_manager ALIAS IrocFleetManager_IrocFleetManager) 
+add_library(iroc_fleet_manager::iroc_fleet_manager ALIAS IrocFleetManager_IrocFleetManager)
 
 set_target_properties(IrocFleetManager_IrocFleetManager
   PROPERTIES
-    EXPORT_NAME iroc_fleet_manager 
-    OUTPUT_NAME iroc_fleet_manager 
+    EXPORT_NAME iroc_fleet_manager
+    OUTPUT_NAME iroc_fleet_manager
 )
 
 target_sources(IrocFleetManager_IrocFleetManager
@@ -165,7 +165,7 @@ target_link_libraries(IROCFleetManager_WaypointPlanner
     IROCFleetManager
     iroc_fleet_manager::iroc_fleet_manager
     rclcpp::rclcpp
-    rclcpp_action::rclcpp_action           
+    rclcpp_action::rclcpp_action
     rclcpp_components::component
     pluginlib::pluginlib
     mrs_lib::mrs_lib
@@ -197,7 +197,7 @@ add_library(EnergyAwareMCPP SHARED
 target_include_directories(EnergyAwareMCPP
   PUBLIC
   $<BUILD_INTERFACE:${ENERGY_AWARE_MCPP_SRC_DIR}/include/EnergyAwareMCPP>
-    $<INSTALL_INTERFACE:include/${PROJECT_NAME}/EnergyAwareMCPP>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}/EnergyAwareMCPP>
 )
 
 ament_target_dependencies(EnergyAwareMCPP PUBLIC mrs_msgs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,9 @@ foreach(DEP IN LISTS DEPENDENCIES)
   find_package(${DEP} REQUIRED)
 endforeach()
 
+# ENERGY_AWARE_MCPP dependencies
+find_package(yaml-cpp REQUIRED)
+
 ## --------------------------------------------------------------
 ## |                      Generate Interfaces                   |
 ## --------------------------------------------------------------
@@ -198,6 +201,11 @@ target_include_directories(EnergyAwareMCPP
 )
 
 ament_target_dependencies(EnergyAwareMCPP PUBLIC mrs_msgs)
+
+target_link_libraries(EnergyAwareMCPP
+  PUBLIC
+    yaml-cpp::yaml-cpp
+)
 
 # ## | ----------- IROCFleetManager_CoveragePlanner ------------ |
 

--- a/package.xml
+++ b/package.xml
@@ -27,6 +27,7 @@
   <depend>iroc_mission_handler</depend>
   <depend>nlohmann-json-dev</depend>
   <depend>iroc_common</depend>
+  <depend>yaml-cpp</depend>
   
   <exec_depend>rosidl_default_runtime</exec_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>


### PR DESCRIPTION
This pull request updates the build configuration to add support for the `yaml-cpp` library in the `EnergyAwareMCPP` package. The changes ensure that `yaml-cpp` is properly found, linked, and declared as a dependency.

Build system and dependency updates:

* Added `find_package(yaml-cpp REQUIRED)` to `CMakeLists.txt` to ensure the `yaml-cpp` library is found during the build process.
* Updated `target_link_libraries` for the `EnergyAwareMCPP` target to link against `yaml-cpp::yaml-cpp`.
* Declared `yaml-cpp` as a package dependency in `package.xml` to ensure it is installed and available.